### PR TITLE
Allow TinyMessenger to be used in PCL code 

### DIFF
--- a/src/TinyMessenger/TinyMessenger/TinyMessenger.cs
+++ b/src/TinyMessenger/TinyMessenger/TinyMessenger.cs
@@ -744,7 +744,10 @@ namespace TinyMessenger
                                            where object.ReferenceEquals(sub.Subscription.SubscriptionToken, subscriptionToken)
                                            select sub).ToList();
 
-                currentlySubscribed.ForEach(sub => currentSubscriptions.Remove(sub));
+				foreach (var sub in currentlySubscribed)
+				{
+					currentSubscriptions.Remove(sub);
+				}
             }
         }
 
@@ -766,18 +769,18 @@ namespace TinyMessenger
                                        select sub).ToList();
             }
 
-            currentlySubscribed.ForEach(sub =>
-            {
-                try
-                {
-                    sub.Proxy.Deliver(message, sub.Subscription);
-                }
-                catch (Exception)
-                {
-                    // Ignore any errors and carry on
-                    // TODO - add to a list of erroring subs and remove them?
-                }
-            });
+
+			foreach (var sub in currentlySubscribed) {
+				try
+				{
+					sub.Proxy.Deliver(message, sub.Subscription);
+				}
+				catch (Exception)
+				{
+					// Ignore any errors and carry on
+					// TODO - add to a list of erroring subs and remove them?
+				}
+			}
         }
 
         private void PublishAsyncInternal<TMessage>(TMessage message, AsyncCallback callback) where TMessage : class, ITinyMessage


### PR DESCRIPTION
Hi @Grumpydev

Unfortunately the PCL Generic `List<T>` doesn't implement `ForEach` 

This change simply replaces the two ForEach calls with foreach iterations instead.

Sadly, the change also stuffs up the formatting (sorry - on a Mac right now and MonoDevelop hates me).

If you want the contents of this Pull, let me know and I'll try to correct the formatting when I'm back on the PC :)

Stuart (@slodge)
