### PR TITLE
Subscriber error handler

### DIFF
--- a/src/TinyMessenger/TinyMessenger.Tests/TestData/TinyMessengerTestData.cs
+++ b/src/TinyMessenger/TinyMessenger.Tests/TestData/TinyMessengerTestData.cs
@@ -25,4 +25,13 @@ namespace TinyMessenger.Tests.TestData
         }
     }
 
+    public class TestSubscriptionErrorHandler : ISubscriberErrorHandler
+    {
+        public void Handle(ITinyMessage message, Exception exception)
+        {
+            throw exception;
+        }
+    }
+
+
 }

--- a/src/TinyMessenger/TinyMessenger.Tests/TestData/UtilityMethods.cs
+++ b/src/TinyMessenger/TinyMessenger.Tests/TestData/UtilityMethods.cs
@@ -27,6 +27,11 @@ namespace TinyMessenger.Tests.TestData
             return new TinyMessengerHub();
         }
 
+        public static ITinyMessengerHub GetMessengerWithSubscriptionErrorHandler()
+        {
+            return new TinyMessengerHub(new TestSubscriptionErrorHandler());
+        }
+
         public static void FakeDeliveryAction<T>(T message)
             where T:ITinyMessage
         {

--- a/src/TinyMessenger/TinyMessenger.Tests/TinyMessengerTests.cs
+++ b/src/TinyMessenger/TinyMessenger.Tests/TinyMessengerTests.cs
@@ -308,6 +308,16 @@ namespace TinyMessenger.Tests
         }
 
         [TestMethod]
+        [ExpectedException(typeof(NotImplementedException))]
+        public void Publish_SubscriptionThrowingException_DoesThrow()
+        {
+            var messenger = UtilityMethods.GetMessengerWithSubscriptionErrorHandler();
+            messenger.Subscribe<GenericTinyMessage<string>>((m) => { throw new NotImplementedException(); });
+
+            messenger.Publish(new GenericTinyMessage<string>(this, "Testing"));
+        }
+
+        [TestMethod]
         public void PublishAsync_NoCallback_DoesNotThrow()
         {
             var messenger = UtilityMethods.GetMessenger();
@@ -427,5 +437,7 @@ namespace TinyMessenger.Tests
 
             Assert.IsTrue(cancelled);
         }
+
+       
     }
 }

--- a/src/TinyMessenger/TinyMessenger/TinyMessenger.cs
+++ b/src/TinyMessenger/TinyMessenger/TinyMessenger.cs
@@ -20,6 +20,21 @@ using System.Text;
 namespace TinyMessenger
 {
     #region Message Types / Interfaces
+
+    public interface ISubscriberErrorHandler
+    {
+        void Handle(ITinyMessage message, Exception exception);
+    }
+
+    public class DefaultSubscriberErrorHandler : ISubscriberErrorHandler
+    {
+        public void Handle(ITinyMessage message, Exception exception)
+        {
+            //default behaviour is to do nothing
+           
+        }
+    }
+
     /// <summary>
     /// A TinyMessage to be published/delivered by TinyMessenger
     /// </summary>
@@ -394,6 +409,21 @@ namespace TinyMessenger
     /// </summary>
     public sealed class TinyMessengerHub : ITinyMessengerHub
     {
+        readonly ISubscriberErrorHandler _SubscriberErrorHandler;
+
+        #region ctor methods
+
+        public TinyMessengerHub()
+        {
+            _SubscriberErrorHandler = new DefaultSubscriberErrorHandler();
+        }
+
+        public TinyMessengerHub(ISubscriberErrorHandler subscriberErrorHandler)
+        {
+            _SubscriberErrorHandler = subscriberErrorHandler;
+        }
+        #endregion
+
         #region Private Types and Interfaces
         private class WeakTinyMessageSubscription<TMessage> : ITinyMessageSubscription
             where TMessage : class, ITinyMessage
@@ -772,10 +802,10 @@ namespace TinyMessenger
                 {
                     sub.Proxy.Deliver(message, sub.Subscription);
                 }
-                catch (Exception)
+                catch (Exception exception)
                 {
-                    // Ignore any errors and carry on
-                    // TODO - add to a list of erroring subs and remove them?
+                    // By default ignore any errors and carry on
+                    _SubscriberErrorHandler.Handle(message, exception);
                 }
             });
         }


### PR DESCRIPTION
Brief rundown:

* Add a default ctor for the TinyMessengerHub, which uses an internal DefaultSubscriberErrorHandler that swallows any error in the subscriber code (same as previously)
* Add a ctor for TinyMessengerHub that allows injection of an ISubscriberErrorHandler class, so any errors occurring in the subscriber code can be handled how ever we wish
* Add a test to confirm behavior

All changes should be non-breaking.  Confirmed all existing tests are still green.
