### PR TITLE
Refactor to support PCL .NET 4.5

### DIFF
--- a/src/TinyMessenger/TinyMessenger/TinyMessenger.cs
+++ b/src/TinyMessenger/TinyMessenger/TinyMessenger.cs
@@ -15,6 +15,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 
 namespace TinyMessenger
@@ -134,7 +135,7 @@ namespace TinyMessenger
             if (hub == null)
                 throw new ArgumentNullException("hub");
 
-            if (!typeof(ITinyMessage).IsAssignableFrom(messageType))
+            if (!typeof(ITinyMessage).GetTypeInfo().IsAssignableFrom(messageType.GetTypeInfo()))
                 throw new ArgumentOutOfRangeException("messageType");
 
             _Hub = new WeakReference(hub);
@@ -149,7 +150,7 @@ namespace TinyMessenger
 
                 if (hub != null)
                 {
-                    var unsubscribeMethod = typeof(ITinyMessengerHub).GetMethod("Unsubscribe", new Type[] {typeof(TinyMessageSubscriptionToken)});
+                    var unsubscribeMethod = typeof(ITinyMessengerHub).GetTypeInfo().GetDeclaredMethod("Unsubscribe");
                     unsubscribeMethod = unsubscribeMethod.MakeGenericMethod(_MessageType);
                     unsubscribeMethod.Invoke(hub, new object[] {this});
                 }
@@ -409,10 +410,7 @@ namespace TinyMessenger
 
             public bool ShouldAttemptDelivery(ITinyMessage message)
             {
-                if (message == null)
-                    return false;
-
-                if (!(typeof(TMessage).IsAssignableFrom(message.GetType())))
+                if (!(message is TMessage))
                     return false;
 
                 if (!_DeliveryAction.IsAlive)
@@ -472,10 +470,7 @@ namespace TinyMessenger
 
             public bool ShouldAttemptDelivery(ITinyMessage message)
             {
-                if (message == null)
-                    return false;
-
-                if (!(typeof(TMessage).IsAssignableFrom(message.GetType())))
+                if (!(message is TMessage))
                     return false;
 
                 return _MessageFilter.Invoke(message as TMessage);
@@ -738,7 +733,10 @@ namespace TinyMessenger
                                            where object.ReferenceEquals(sub.Subscription.SubscriptionToken, subscriptionToken)
                                            select sub).ToList();
 
-                currentlySubscribed.ForEach(sub => _Subscriptions.Remove(sub));
+                foreach (SubscriptionItem subscriptionItem in currentlySubscribed)
+                {
+                    currentlySubscribed.Remove(subscriptionItem);
+                }
             }
         }
 
@@ -756,7 +754,7 @@ namespace TinyMessenger
                                        select sub).ToList();
             }
 
-            currentlySubscribed.ForEach(sub =>
+            foreach (SubscriptionItem sub in currentlySubscribed)
             {
                 try
                 {
@@ -767,7 +765,7 @@ namespace TinyMessenger
                     // Ignore any errors and carry on
                     // TODO - add to a list of erroring subs and remove them?
                 }
-            });
+            }
         }
 
         private void PublishAsyncInternal<TMessage>(TMessage message, AsyncCallback callback) where TMessage : class, ITinyMessage

--- a/src/TinyMessenger/TinyMessenger/TinyMessenger.cs
+++ b/src/TinyMessenger/TinyMessenger/TinyMessenger.cs
@@ -733,7 +733,7 @@ namespace TinyMessenger
                                            where object.ReferenceEquals(sub.Subscription.SubscriptionToken, subscriptionToken)
                                            select sub).ToList();
 
-                foreach (SubscriptionItem subscriptionItem in currentlySubscribed)
+                foreach (SubscriptionItem subscriptionItem in currentlySubscribed.ToList())
                 {
                     currentlySubscribed.Remove(subscriptionItem);
                 }


### PR DESCRIPTION
These changes break compatibility with .NET 4.0 and PCL .NET 4.0
though, due to the use of GetTypeInfo() extensions in the new
reflection API.

I don't know how you would want to handle this.
1. Scrap support for .NET 4.0
2. No? Dang. Well I see a couple of options.
1. For binary distribution, we can create a .NET 4.5 project and add compile conditions to use old/new reflection API in the 4-5 places in the code. 
2. For .cs file distribution, which seems what the nuget was doing, either the user must manually comment out some code, or maybe we can add two versions of the file with the nuget and use some framework conditional logic in the nuspec to copy in the correct file. Haven't tried that before.

Let me know what you think.
