### PR TITLE
Fixed an issue with ambiguous Unsubscribe and introduced Consume

### DIFF
--- a/src/TinyMessenger/TinyMessenger.Tests/TestData/TinyMessengerTestData.cs
+++ b/src/TinyMessenger/TinyMessenger.Tests/TestData/TinyMessengerTestData.cs
@@ -32,14 +32,20 @@ namespace TinyMessenger.Tests.TestData
     public class InterfaceDerivedMessage<TThings> : ITestMessageInterface
     {
         public object Sender { get; private set; }
+        public bool Consume { get; private set; }
 
         public TThings Things { get; set; }
 
-        public InterfaceDerivedMessage(object sender)
+        public InterfaceDerivedMessage(object sender) : this(sender, false)
+        {
+        }
+
+        public InterfaceDerivedMessage(object sender, bool consume)
         {
             this.Sender = sender;
+            this.Consume = consume;
         }
-}
+    }
 
     public class TestProxy : ITinyMessageProxy
     {

--- a/src/TinyMessenger/TinyMessenger.Tests/TinyMessageSubscriptionTokenTests.cs
+++ b/src/TinyMessenger/TinyMessenger.Tests/TinyMessageSubscriptionTokenTests.cs
@@ -15,11 +15,12 @@ namespace TinyMessenger.Tests
         public void Dispose_WithValidHubReference_UnregistersWithHub()
         {
             var messengerMock = new Moq.Mock<ITinyMessengerHub>();
+
             messengerMock.Setup((messenger) => messenger.Unsubscribe<TestMessage>(Moq.It.IsAny<TinyMessageSubscriptionToken>())).Verifiable();
+
             var token = new TinyMessageSubscriptionToken(messengerMock.Object, typeof(TestMessage));
 
             token.Dispose();
-
             messengerMock.VerifyAll();
         }
 
@@ -27,6 +28,7 @@ namespace TinyMessenger.Tests
         public void Dispose_WithInvalidHubReference_DoesNotThrow()
         {
             var token = UtilityMethods.GetTokenWithOutOfScopeMessenger();
+
             GC.Collect();
             GC.WaitForFullGCComplete(2000);
 
@@ -38,7 +40,6 @@ namespace TinyMessenger.Tests
         public void Ctor_NullHub_ThrowsArgumentNullException()
         {
             var messenger = UtilityMethods.GetMessenger();
-
             var token = new TinyMessageSubscriptionToken(null, typeof(ITinyMessage));
         }
 
@@ -47,7 +48,6 @@ namespace TinyMessenger.Tests
         public void Ctor_InvalidMessageType_ThrowsArgumentOutOfRangeException()
         {
             var messenger = UtilityMethods.GetMessenger();
-
             var token = new TinyMessageSubscriptionToken(messenger, typeof(object));
         }
 
@@ -55,7 +55,6 @@ namespace TinyMessenger.Tests
         public void Ctor_ValidHubAndMessageType_DoesNotThrow()
         {
             var messenger = UtilityMethods.GetMessenger();
-
             var token = new TinyMessageSubscriptionToken(messenger, typeof(TestMessage));
         }
     }


### PR DESCRIPTION
After my previous pull request introduced an Unsubscribe that was message-less it breaks the reflection that looks for the Unsubscribe method, there's multiple now so it gets confused.

To that end I've fixed up the reflection so it finds the correct one.

I also had the need to only process the message once by one subscriber where there could be multiple subscribers listening for the message. To resolve this I introduced a Consume flag into ITinyMessage and also fixed up some of the base/abstract classes that depend on it.

I'm not too sure on changing ITinyMessage directly, it could break anything that inherits from it. Generally I've always based my messages on TinyMessageBase but open to solutions around this, not sure, another interface to look for?